### PR TITLE
Use set_default_header attribute to fix workaround

### DIFF
--- a/src/wrapica/project_pipelines/classes/analysis.py
+++ b/src/wrapica/project_pipelines/classes/analysis.py
@@ -479,7 +479,7 @@ class ICAv2PipelineAnalysis:
         # Set the analysis
         self.analysis: Optional[Union[CreateCwlAnalysis, CreateNextflowAnalysis]] = None
 
-    def __call__(self) -> Union[Analysis, str]:
+    def __call__(self) -> Analysis:
         """
         Fix up the engine parameters, and generate a CWL Analysis Object
         :return:

--- a/src/wrapica/project_pipelines/classes/nextflow_analysis.py
+++ b/src/wrapica/project_pipelines/classes/nextflow_analysis.py
@@ -6,7 +6,7 @@ Nextflow analysis
 
 # Imports
 from pathlib import Path
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional
 
 # Libica imports
 from libica.openapi.v2.model.analysis import Analysis
@@ -369,7 +369,7 @@ class ICAv2NextflowPipelineAnalysis(ICAv2PipelineAnalysis):
             analysis_output=self.engine_parameters.analysis_output
         )
 
-    def launch_analysis(self) -> Union[Analysis, str]:
+    def launch_analysis(self) -> Analysis:
         from ..functions.project_pipelines_functions import launch_nextflow_workflow
         return launch_nextflow_workflow(
             project_id=self.project_id,


### PR DESCRIPTION
Rollback #24

Use set_default_header for api_client instead and set to v3 json.  

Based off example in https://github.com/umccr-illumina/libica/blob/main/examples/issue_135.py