### PR TITLE
Nextflow parameters need to be strings

### DIFF
--- a/src/wrapica/enums/__init__.py
+++ b/src/wrapica/enums/__init__.py
@@ -119,6 +119,7 @@ class StructuredInputParameterType(Enum):
     STRING = "string"
     INTEGER = "integer"
     OPTION = "options"
+    FLOAT = "float"
 
 
 class StructuredInputParameterTypeMapping(Enum):
@@ -126,6 +127,7 @@ class StructuredInputParameterTypeMapping(Enum):
     STRING = str
     INTEGER = int
     OPTION = str
+    FLOAT = float
 
 
 class AnalysisLogStreamName(Enum):

--- a/src/wrapica/project_pipelines/classes/nextflow_analysis.py
+++ b/src/wrapica/project_pipelines/classes/nextflow_analysis.py
@@ -33,6 +33,7 @@ from ...enums import (
     StructuredInputParameterType, StructuredInputParameterTypeMapping
 )
 from ...utils.logger import get_logger
+from ...utils.miscell import is_str_type_representation, nextflow_parameter_to_str
 
 Analysis = Union[AnalysisV3, AnalysisV4]
 
@@ -161,7 +162,7 @@ class ICAv2NextflowAnalysisInput(ICAv2AnalysisInput):
                 if parameter.code == configuration_parameter.get("code"):
                     if not (
                         # Check if the parameter value is of the expected configuration parameter type
-                        isinstance(
+                        is_str_type_representation(
                             parameter.value,
                             StructuredInputParameterTypeMapping[
                                 StructuredInputParameterType(
@@ -218,7 +219,7 @@ class ICAv2NextflowAnalysisInput(ICAv2AnalysisInput):
                     self.parameters.append(
                         AnalysisParameterInput(
                             code=key,
-                            multi_value=value,
+                            multi_value=map(nextflow_parameter_to_str, value)
                         )
                     )
             else:
@@ -233,7 +234,7 @@ class ICAv2NextflowAnalysisInput(ICAv2AnalysisInput):
                     self.parameters.append(
                         AnalysisParameterInput(
                             code=key,
-                            value=str(value)
+                            value=nextflow_parameter_to_str(value)
                         )
                     )
 

--- a/src/wrapica/utils/miscell.py
+++ b/src/wrapica/utils/miscell.py
@@ -5,7 +5,7 @@ Functions that don't quite do anywhere else
 """
 # Standard imports
 import re
-from typing import Dict, Any, Union, List
+from typing import Dict, Any, Union, List, Type
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -76,3 +76,34 @@ def build_curl_body_from_libica_item(libica_item: Any) -> Union[Dict, Any]:
             output_value = value
         open_api_body_dict[libica_item.attribute_map.get(key)] = output_value
     return open_api_body_dict
+
+
+def is_str_type_representation(value: str, type: Type) -> bool:
+    """
+    Check if the string 'value' can be represented as the type 'type'
+
+    :param value:
+    :param type:
+    :return:
+    """
+
+    try:
+        type(value)
+        return True
+    except ValueError:
+        return False
+
+
+def nextflow_parameter_to_str(parameter: Any) -> str:
+    """
+    Coerce the parameter to a string representation of the type
+
+    This is easy for ints + floats, for Boolean types we make sure the string is lowercase
+
+    :param parameter:
+    :param type:
+    :return:
+    """
+    if type(parameter) == bool:
+        return str(parameter).lower()
+    return str(parameter)


### PR DESCRIPTION
But also need to check if their values are string representations of their actual types

Error where StartsFromFastq was complaining because it was of 'options' type and moved to boolean type. Analysis check falied because 'true' was not boolean, because we had already coerced it to a string type