### PR TITLE
Add python 3.13 and 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Secondary level functions for ICAv2 based off libica"
 readme = "Readme.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12,<3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Add 3.13 and 3.14 compatibility, code compiler IDE showed no new issues when adding these python versions

Resolves #118